### PR TITLE
Add new build 2018.1.41051

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM anapsix/alpine-java:8
 
 ARG YOUTRACK_URL=https://download.jetbrains.com/charisma
 ARG YOUTRACK_VERSION=2018.1
-ARG YOUTRACK_BUILD=40341
+ARG YOUTRACK_BUILD=41051
 ARG YOUTRACK_LOCALE=en_us
 
 LABEL name=docker-youtrack-base \

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # docker-youtrack-base
 
 [![](https://images.microbadger.com/badges/image/pythoninja/docker-youtrack-base.svg)](https://microbadger.com/images/pythoninja/docker-youtrack-base "Get your own image badge on microbadger.com")
-[![](http://api.stas.pw/v1/youtrack/latest.svg)](https://www.jetbrains.com/youtrack/download/get_youtrack.html "Get latest YouTrack binary")
 
 Docker YouTrack image based on Alpine Java 8.
 
-Built with YouTrack version 2018.1.40341 (March 23, 2018)
+Built with YouTrack version 2018.1.41051 (April 20, 2018)
 
 This project was inspired from:
 1. [uniplug/youtrack-docker](https://github.com/uniplug/youtrack-docker)
@@ -15,14 +14,14 @@ This project was inspired from:
 
 **Fresh tags:**
 
-1. `latest` or `2018.1.40341`
+1. `latest` or `2018.1.41051`
 
 **Old tags:**
 
+1. `2018.1.40341`
 1. `2017.4.39083`
 1. `2017.4.38399` 
 1. `2017.4.37623` 
-1. `2017.3.37517` 
 
 More old tags see on [Docker Hub](https://hub.docker.com/r/pythoninja/docker-youtrack-base/tags/)
 


### PR DESCRIPTION
1. New release based on YouTrack 2018.1.41051
2. Removed badge from README